### PR TITLE
Added automated version tagging workflow

### DIFF
--- a/.github/workflow/tag_version_and_release.yml
+++ b/.github/workflow/tag_version_and_release.yml
@@ -1,0 +1,14 @@
+name: Tag Version and Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  tag_version_and_release:
+    uses: RxnRover/.github/.github/workflows/tag_version_and_release_main.yml@main


### PR DESCRIPTION
## Description

Creates automated version tagging workflow based on the reusable workflow at https://github.com/RxnRover/.github/blob/main/.github/workflows/tag_version_and_release_main.yml. It is a fixed version that accounts for the default branch here being named `master`, not `main`.

## Related Issues/Pull Requests

Closes #2.
